### PR TITLE
Otp inputs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 npm run format
 npm run lint
+npm run typescript
 npm run build

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typescript": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier . --write",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import About from './pages/about/about';
 import PageNotFound from './pages/page-not-found/page-not-found';
 import ExpandedCard from './components/cards/card-expanded/expanded-card';
 import Contact from './pages/contact/contact';
+import SignIn from './pages/sign-in/sign-in';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
@@ -21,6 +22,7 @@ const router = createBrowserRouter(
         <Route index element={<HomePage />} />
         <Route path="about" element={<About />} />
         <Route path="contact" element={<Contact />} />
+        <Route path="sign-in" element={<SignIn />} />
         <Route path="countries/:id" element={<ExpandedCard />} />
         <Route path="*" element={<PageNotFound />} />
       </Route>

--- a/src/components/form/input/otp-input/otp-container.module.css
+++ b/src/components/form/input/otp-input/otp-container.module.css
@@ -1,0 +1,5 @@
+.container{
+    display: flex;
+    flex-direction: row;
+    column-gap: 24px;
+}

--- a/src/components/form/input/otp-input/otp-container.module.css
+++ b/src/components/form/input/otp-input/otp-container.module.css
@@ -1,5 +1,5 @@
-.container{
-    display: flex;
-    flex-direction: row;
-    column-gap: 24px;
+.container {
+  display: flex;
+  flex-direction: row;
+  column-gap: 24px;
 }

--- a/src/components/form/input/otp-input/otp-container.tsx
+++ b/src/components/form/input/otp-input/otp-container.tsx
@@ -1,27 +1,84 @@
 import styles from './otp-container.module.css';
 import otpInputSd from './otp-input-sd';
 import { useParams } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import OtpInput from './otp-input';
 interface NumberOfInputsProps {
   numberOfInputs: number;
 }
-const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs }) => {
+const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs, codeFilled }) => {
   const { lang } = useParams();
   const content = lang === 'en' ? otpInputSd.en : otpInputSd.ka;
   const [values, setValues] = useState(Array(numberOfInputs).fill(''));
 
+  const ref = useRef<(HTMLInputElement | null)[]>(
+    Array(numberOfInputs).fill(null),
+  );
+  function checkCodeFill(values){
+    if(values.every(value => value !== undefined && value !== null && value !== "")){
+        codeFilled(values);
+    }
+  }
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>,
     index: number,
   ) => {
     const newValue = e.target.value;
+    if (/^[0-9]$/.test(newValue)) {
+      setValues((prevValues) => {
+        const newValues = [...prevValues];
+        newValues[index] = newValue;
+        checkCodeFill(newValues)
+        return newValues;
+      });
+    }
 
-    setValues((prevValues) => {
-      const newValues = [...prevValues];
-      newValues[index] = newValue;
-      return newValues;
-    });
+    if (newValue && /^[0-9]$/.test(newValue) && index < values.length - 1) {
+      ref.current[index + 1]?.focus();
+    } else if (index === values.length - 1 && newValue) {
+      e.target.blur();
+    }
+  };
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    index: number,
+  ) => {
+    if (e.key === 'Backspace') {
+      e.preventDefault();
+      if (values[index] === '') {
+        if (index > 0) {
+          ref.current[index - 1]?.focus();
+        }
+        } else {
+          setValues((prevValues) => {
+            const newValues = [...prevValues];
+            newValues[index] = '';
+            return newValues;
+          });
+      }
+    }
+  };
+  const handlePaste = (
+    e: React.ClipboardEvent<HTMLInputElement>,
+    index: number,
+  ) => {
+    e.preventDefault();
+    const pastedData = e.clipboardData.getData('text');
+    if(/^\d+$/.test(pastedData)){
+        setValues((prevValues) => {
+            const newValues = [...prevValues];
+            const length = Math.min(pastedData.length, numberOfInputs - index);
+            for (let i = 0; i < length; i++) {
+              newValues[index + i] = pastedData[i];
+            }
+            checkCodeFill(newValues)
+            return newValues;
+          });
+          ref.current[index]?.blur();
+          
+    }
+  //1234
+
   };
   return (
     <div>
@@ -32,6 +89,9 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs }) => {
             key={i}
             value={values[i]}
             onChange={(e) => handleChange(e, i)}
+            onKeyDown={(e) => handleKeyDown(e, i)}
+            onPaste={(e) => handlePaste(e, i)}
+            ref={(el) => (ref.current[i] = el)}
           />
         ))}
       </div>

--- a/src/components/form/input/otp-input/otp-container.tsx
+++ b/src/components/form/input/otp-input/otp-container.tsx
@@ -60,11 +60,9 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({
           ref.current[index - 1]?.focus();
           return newValues;
         });
-      }
-      else if(index > 0) {
+      } else if (index > 0) {
         ref.current[index - 1]?.focus();
-        
-      } 
+      }
     }
   };
   const handlePaste = (

--- a/src/components/form/input/otp-input/otp-container.tsx
+++ b/src/components/form/input/otp-input/otp-container.tsx
@@ -53,17 +53,18 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({
   ) => {
     if (e.key === 'Backspace') {
       e.preventDefault();
-      if (values[index] === '') {
-        if (index > 0) {
-          ref.current[index - 1]?.focus();
-        }
-      } else {
+      if (values[index] !== '') {
         setValues((prevValues) => {
           const newValues = [...prevValues];
           newValues[index] = '';
+          ref.current[index - 1]?.focus();
           return newValues;
         });
       }
+      else if(index > 0) {
+        ref.current[index - 1]?.focus();
+        
+      } 
     }
   };
   const handlePaste = (

--- a/src/components/form/input/otp-input/otp-container.tsx
+++ b/src/components/form/input/otp-input/otp-container.tsx
@@ -1,7 +1,7 @@
 import styles from './otp-container.module.css';
 import otpInputSd from './otp-input-sd';
 import { useParams } from 'react-router-dom';
-import { useState, } from 'react';
+import { useState } from 'react';
 import OtpInput from './otp-input';
 interface NumberOfInputsProps {
   numberOfInputs: number;

--- a/src/components/form/input/otp-input/otp-container.tsx
+++ b/src/components/form/input/otp-input/otp-container.tsx
@@ -40,7 +40,7 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({
         return newValues;
       });
     }
-   
+
     if (newValue && /^[0-9]$/.test(newValue) && index < values.length - 1) {
       ref.current[index + 1]?.focus();
     } else if (index === values.length - 1 && newValue) {
@@ -83,7 +83,7 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({
       });
       ref.current[index]?.blur();
     }
-    //1234
+    //1234 ABCD
   };
   return (
     <div>

--- a/src/components/form/input/otp-input/otp-container.tsx
+++ b/src/components/form/input/otp-input/otp-container.tsx
@@ -5,8 +5,12 @@ import { useState, useRef } from 'react';
 import OtpInput from './otp-input';
 interface NumberOfInputsProps {
   numberOfInputs: number;
+  codeFilled: (values: string[]) => void;
 }
-const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs, codeFilled }) => {
+const OtpContainer: React.FC<NumberOfInputsProps> = ({
+  numberOfInputs,
+  codeFilled,
+}) => {
   const { lang } = useParams();
   const content = lang === 'en' ? otpInputSd.en : otpInputSd.ka;
   const [values, setValues] = useState(Array(numberOfInputs).fill(''));
@@ -14,9 +18,13 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs, codeFille
   const ref = useRef<(HTMLInputElement | null)[]>(
     Array(numberOfInputs).fill(null),
   );
-  function checkCodeFill(values){
-    if(values.every(value => value !== undefined && value !== null && value !== "")){
-        codeFilled(values);
+  function checkCodeFill(values: string[]) {
+    if (
+      values.every(
+        (value) => value !== undefined && value !== null && value !== '',
+      )
+    ) {
+      codeFilled(values);
     }
   }
   const handleChange = (
@@ -28,7 +36,7 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs, codeFille
       setValues((prevValues) => {
         const newValues = [...prevValues];
         newValues[index] = newValue;
-        checkCodeFill(newValues)
+        checkCodeFill(newValues);
         return newValues;
       });
     }
@@ -49,12 +57,12 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs, codeFille
         if (index > 0) {
           ref.current[index - 1]?.focus();
         }
-        } else {
-          setValues((prevValues) => {
-            const newValues = [...prevValues];
-            newValues[index] = '';
-            return newValues;
-          });
+      } else {
+        setValues((prevValues) => {
+          const newValues = [...prevValues];
+          newValues[index] = '';
+          return newValues;
+        });
       }
     }
   };
@@ -64,21 +72,19 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs, codeFille
   ) => {
     e.preventDefault();
     const pastedData = e.clipboardData.getData('text');
-    if(/^\d+$/.test(pastedData)){
-        setValues((prevValues) => {
-            const newValues = [...prevValues];
-            const length = Math.min(pastedData.length, numberOfInputs - index);
-            for (let i = 0; i < length; i++) {
-              newValues[index + i] = pastedData[i];
-            }
-            checkCodeFill(newValues)
-            return newValues;
-          });
-          ref.current[index]?.blur();
-          
+    if (/^\d+$/.test(pastedData)) {
+      setValues((prevValues) => {
+        const newValues = [...prevValues];
+        const length = Math.min(pastedData.length, numberOfInputs - index);
+        for (let i = 0; i < length; i++) {
+          newValues[index + i] = pastedData[i];
+        }
+        checkCodeFill(newValues);
+        return newValues;
+      });
+      ref.current[index]?.blur();
     }
-  //1234
-
+    //1234
   };
   return (
     <div>

--- a/src/components/form/input/otp-input/otp-container.tsx
+++ b/src/components/form/input/otp-input/otp-container.tsx
@@ -40,7 +40,7 @@ const OtpContainer: React.FC<NumberOfInputsProps> = ({
         return newValues;
       });
     }
-
+   
     if (newValue && /^[0-9]$/.test(newValue) && index < values.length - 1) {
       ref.current[index + 1]?.focus();
     } else if (index === values.length - 1 && newValue) {

--- a/src/components/form/input/otp-input/otp-container.tsx
+++ b/src/components/form/input/otp-input/otp-container.tsx
@@ -1,0 +1,41 @@
+import styles from './otp-container.module.css';
+import otpInputSd from './otp-input-sd';
+import { useParams } from 'react-router-dom';
+import { useState, } from 'react';
+import OtpInput from './otp-input';
+interface NumberOfInputsProps {
+  numberOfInputs: number;
+}
+const OtpContainer: React.FC<NumberOfInputsProps> = ({ numberOfInputs }) => {
+  const { lang } = useParams();
+  const content = lang === 'en' ? otpInputSd.en : otpInputSd.ka;
+  const [values, setValues] = useState(Array(numberOfInputs).fill(''));
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    index: number,
+  ) => {
+    const newValue = e.target.value;
+
+    setValues((prevValues) => {
+      const newValues = [...prevValues];
+      newValues[index] = newValue;
+      return newValues;
+    });
+  };
+  return (
+    <div>
+      <h1>{content.title}</h1>
+      <div className={styles.container}>
+        {Array.from({ length: numberOfInputs }, (_, i) => (
+          <OtpInput
+            key={i}
+            value={values[i]}
+            onChange={(e) => handleChange(e, i)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+export default OtpContainer;

--- a/src/components/form/input/otp-input/otp-input-sd-interface.ts
+++ b/src/components/form/input/otp-input/otp-input-sd-interface.ts
@@ -1,9 +1,9 @@
-interface OtpInputSdInterface{
-    ka: {
-       title: string;
-    },
-    en: {
-        title: string;
-     },
+interface OtpInputSdInterface {
+  ka: {
+    title: string;
+  };
+  en: {
+    title: string;
+  };
 }
 export default OtpInputSdInterface;

--- a/src/components/form/input/otp-input/otp-input-sd-interface.ts
+++ b/src/components/form/input/otp-input/otp-input-sd-interface.ts
@@ -1,0 +1,9 @@
+interface OtpInputSdInterface{
+    ka: {
+       title: string;
+    },
+    en: {
+        title: string;
+     },
+}
+export default OtpInputSdInterface;

--- a/src/components/form/input/otp-input/otp-input-sd.ts
+++ b/src/components/form/input/otp-input/otp-input-sd.ts
@@ -1,9 +1,9 @@
-const otpInputSd ={
-    ka: {
-        title: "SMS-ით მიღებული კოდი"
-    },
-    en: {
-        title: "One time password"
-    }
-}
+const otpInputSd = {
+  ka: {
+    title: 'SMS-ით მიღებული კოდი',
+  },
+  en: {
+    title: 'One time password',
+  },
+};
 export default otpInputSd;

--- a/src/components/form/input/otp-input/otp-input-sd.ts
+++ b/src/components/form/input/otp-input/otp-input-sd.ts
@@ -1,0 +1,9 @@
+const otpInputSd ={
+    ka: {
+        title: "SMS-ით მიღებული კოდი"
+    },
+    en: {
+        title: "One time password"
+    }
+}
+export default otpInputSd;

--- a/src/components/form/input/otp-input/otp-input.module.css
+++ b/src/components/form/input/otp-input/otp-input.module.css
@@ -1,19 +1,19 @@
 .input {
-    height: 4rem;
-    width: 50px;
-    border: 1px solid var(--stroke-softer);
-    border-radius: 0.25rem;
-    background-color: var(--surface-1);
-    padding: 1rem;
-    font-size: 1rem;
-    color: var(--color-primary-text);
-  }
-  .input::placeholder {
-    font-size: 1rem;
-    color: var(--color-secondary-text);
-  }
-  .error {
-    color: var(--color-error-text);
-    font-size: 0.8rem;
-    padding-top: 0.5rem;
-  }
+  height: 4rem;
+  width: 50px;
+  border: 1px solid var(--stroke-softer);
+  border-radius: 0.25rem;
+  background-color: var(--surface-1);
+  padding: 1rem;
+  font-size: 1rem;
+  color: var(--color-primary-text);
+}
+.input::placeholder {
+  font-size: 1rem;
+  color: var(--color-secondary-text);
+}
+.error {
+  color: var(--color-error-text);
+  font-size: 0.8rem;
+  padding-top: 0.5rem;
+}

--- a/src/components/form/input/otp-input/otp-input.module.css
+++ b/src/components/form/input/otp-input/otp-input.module.css
@@ -1,0 +1,19 @@
+.input {
+    height: 4rem;
+    width: 50px;
+    border: 1px solid var(--stroke-softer);
+    border-radius: 0.25rem;
+    background-color: var(--surface-1);
+    padding: 1rem;
+    font-size: 1rem;
+    color: var(--color-primary-text);
+  }
+  .input::placeholder {
+    font-size: 1rem;
+    color: var(--color-secondary-text);
+  }
+  .error {
+    color: var(--color-error-text);
+    font-size: 0.8rem;
+    padding-top: 0.5rem;
+  }

--- a/src/components/form/input/otp-input/otp-input.tsx
+++ b/src/components/form/input/otp-input/otp-input.tsx
@@ -1,14 +1,21 @@
- import styles from "./otp-input.module.css"
- interface OtpInputProps{
-    key: number;
-    value: string;
-    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
- }
- const OtpInput:React.FC<OtpInputProps> = ({key, value, onChange}) => {
-    return(
-        <div>
-            <input key={key} value={value} onChange={onChange} className={styles.input} placeholder="X" maxLength={1}/>
-        </div>
-    )
- }
- export default OtpInput;
+import styles from './otp-input.module.css';
+interface OtpInputProps {
+  key: number;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+const OtpInput: React.FC<OtpInputProps> = ({ key, value, onChange }) => {
+  return (
+    <div>
+      <input
+        key={key}
+        value={value}
+        onChange={onChange}
+        className={styles.input}
+        placeholder="X"
+        maxLength={1}
+      />
+    </div>
+  );
+};
+export default OtpInput;

--- a/src/components/form/input/otp-input/otp-input.tsx
+++ b/src/components/form/input/otp-input/otp-input.tsx
@@ -1,0 +1,14 @@
+ import styles from "./otp-input.module.css"
+ interface OtpInputProps{
+    key: number;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+ }
+ const OtpInput:React.FC<OtpInputProps> = ({key, value, onChange}) => {
+    return(
+        <div>
+            <input key={key} value={value} onChange={onChange} className={styles.input} placeholder="X" maxLength={1}/>
+        </div>
+    )
+ }
+ export default OtpInput;

--- a/src/components/form/input/otp-input/otp-input.tsx
+++ b/src/components/form/input/otp-input/otp-input.tsx
@@ -1,21 +1,27 @@
 import styles from './otp-input.module.css';
+import { forwardRef } from 'react';
 interface OtpInputProps {
-  key: number;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onPaste: (e: React.ClipboardEvent<HTMLInputElement>) => void;
 }
-const OtpInput: React.FC<OtpInputProps> = ({ key, value, onChange }) => {
-  return (
-    <div>
-      <input
-        key={key}
-        value={value}
-        onChange={onChange}
-        className={styles.input}
-        placeholder="X"
-        maxLength={1}
-      />
-    </div>
-  );
-};
+const OtpInput = forwardRef<HTMLInputElement, OtpInputProps>(
+  ({ value, onChange, onKeyDown, onPaste }, ref) => {
+    return (
+      <div>
+        <input
+          value={value}
+          onChange={onChange}
+          className={styles.input}
+          placeholder="X"
+          maxLength={1}
+          ref={ref}
+          onKeyDown={onKeyDown}
+          onPaste={onPaste}
+        />
+      </div>
+    );
+  },
+);
 export default OtpInput;

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -42,6 +42,9 @@ const Header: React.FC = () => {
               <NavLink to={to}>
                 <Button className="buttonSecondaryS" title={title} />
               </NavLink>
+              <NavLink to="sign-in">
+                <Button className="buttonSecondaryS" title="sign in" />
+              </NavLink>
             </ul>
           </nav>
         </div>

--- a/src/pages/sign-in/sign-in.tsx
+++ b/src/pages/sign-in/sign-in.tsx
@@ -1,0 +1,14 @@
+import Form from "@/components/form/form";
+import OtpContainer from "@/components/form/input/otp-input/otp-container";
+
+const SignIn:React.FC = () => {
+    return(
+        <div className="container-xl">
+            <Form>
+                <OtpContainer numberOfInputs={4}/>
+            </Form>
+            
+        </div>
+    )
+}
+export default SignIn;

--- a/src/pages/sign-in/sign-in.tsx
+++ b/src/pages/sign-in/sign-in.tsx
@@ -2,10 +2,13 @@ import Form from '@/components/form/form';
 import OtpContainer from '@/components/form/input/otp-input/otp-container';
 
 const SignIn: React.FC = () => {
+ function codeFilled(values){
+    console.log("fom success")
+ }
   return (
     <div className="container-xl">
       <Form>
-        <OtpContainer numberOfInputs={4} />
+        <OtpContainer numberOfInputs={4} codeFilled={codeFilled}/>
       </Form>
     </div>
   );

--- a/src/pages/sign-in/sign-in.tsx
+++ b/src/pages/sign-in/sign-in.tsx
@@ -1,14 +1,13 @@
 import Form from '@/components/form/form';
 import OtpContainer from '@/components/form/input/otp-input/otp-container';
-
 const SignIn: React.FC = () => {
- function codeFilled(values){
-    console.log("fom success")
- }
+  function codeFilled(values: string[]) {
+    console.log(values);
+  }
   return (
     <div className="container-xl">
       <Form>
-        <OtpContainer numberOfInputs={4} codeFilled={codeFilled}/>
+        <OtpContainer numberOfInputs={4} codeFilled={codeFilled} />
       </Form>
     </div>
   );

--- a/src/pages/sign-in/sign-in.tsx
+++ b/src/pages/sign-in/sign-in.tsx
@@ -1,14 +1,13 @@
-import Form from "@/components/form/form";
-import OtpContainer from "@/components/form/input/otp-input/otp-container";
+import Form from '@/components/form/form';
+import OtpContainer from '@/components/form/input/otp-input/otp-container';
 
-const SignIn:React.FC = () => {
-    return(
-        <div className="container-xl">
-            <Form>
-                <OtpContainer numberOfInputs={4}/>
-            </Form>
-            
-        </div>
-    )
-}
+const SignIn: React.FC = () => {
+  return (
+    <div className="container-xl">
+      <Form>
+        <OtpContainer numberOfInputs={4} />
+      </Form>
+    </div>
+  );
+};
 export default SignIn;


### PR DESCRIPTION
Add OTP inputs
- Add OTP input functionality to allow users to enter one-time passwords. 
- Validate inputs to ensure only numeric digits are accepted. 
- Implement automatic focus transition between inputs. 
- Handle backspace events to allow deletion and navigation between fields. 
- Support pasting multiple digits into the input fields.

Add typescript check in pre-commit